### PR TITLE
Drop the minimum version of Python needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = [
 ]
 


### PR DESCRIPTION
Although people should be moving to Python 3.10+, the code has no requirements that will break at 3.8 or 3.9