### PR TITLE
Extend citation parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,51 @@ Similarly you can get a list of the citations for only the called functions duri
 citation_list = get_used_citations()
 ```
 
-## Exporing Imports
+## Citation Formats
+
+Citation information is pulled from the object's docstring. The extractor looks for sections denoted by keywords 'citation', 'citations', 'reference', or 'references'. These citation sections can be provided in either numpy or Google format. Here are some valid citation notations:
+
+**Underlined section**
+
+Underlined sections look for section delimiters of the form "keyword\n-------" with at least 2 dashes making up the underline. The citation section includes all text until the end of the string or the next section header.
+
+Examples:
+
+```
+Citation
+--------
+    Author, Title, etc.
+```
+
+or
+
+```
+Citations
+---------
+    Author1, Title2, etc.
+    Author2, Title2, etc.
+```
+
+**Colon-specified section**
+
+Colon-specified sections look for section header where a line starts with "keyword:". The citation section includes all text until the end of the string or the next section header, including text following the section header itself.
+
+Example single line citation:
+
+```
+Citation: Author, title, etc.
+```
+
+Example multi-line citation:
+
+```
+Citation:
+    Author,
+    title,
+    etc.
+```
+
+## Exploring Imports
 
 Since some packages need to be cited when they are used, you can also call
 

--- a/docs/notebooks/intro_notebook.ipynb
+++ b/docs/notebooks/intro_notebook.ipynb
@@ -80,22 +80,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4349a8d",
+   "id": "d3145b54",
    "metadata": {},
    "source": [
-    "As we can see the function has been included in the list of all citations, but not the list of used citations. This changes if we call the function (which means it has been used).\n",
-    "\n",
-    "Each citation is displayed as the thing to cite, including module and name information, and then the citation string. By default CitationCompass will parse the object's docstring to look for lines starting with \"Citation:\", \"Reference:\", etc. The full list of lowercased strings can be found at `cc.docstring_utils._CITATION_HEADER_KEYWORDS`. If such a label is found, CitationCompass will extract all text until the next newline as the citation. If no such label is found, CitationCompass will just return the docstring as the citation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0528277",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cc.docstring_utils._CITATION_HEADER_KEYWORDS"
+    "As we can see the function has been included in the list of all citations, but not the list of used citations. This changes if we call the function (which means it has been used)."
    ]
   },
   {
@@ -107,6 +95,18 @@
    "source": [
     "_ = my_function()\n",
     "print_citations_state()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4349a8d",
+   "metadata": {},
+   "source": [
+    "## Citation Formats\n",
+    "\n",
+    "Each citation is displayed as the thing to cite, including module and name information, and then the citation string. By default CitationCompass will parse the object's docstring.  The extractor looks for sections denoted by keywords 'citation', 'citations', 'reference', or 'references'. These citation sections can be provided in either numpy or Google format.\n",
+    "\n",
+    "Underlined delimited section sections look for section delimiters of the form \"keyword\\n-------\" with at least 2 dashes making up the underline. The citation section includes all text until the end of the string or the next section header."
    ]
   },
   {
@@ -132,7 +132,8 @@
     "def my_function_2(x):\n",
     "    \"\"\"This is my second function.\n",
     "\n",
-    "    Citation:\n",
+    "    Citation\n",
+    "    --------\n",
     "    CitationCompass\n",
     "    February 2025\n",
     "\n",
@@ -178,7 +179,10 @@
    "outputs": [],
    "source": [
     "class ExampleClass(cc.CiteClass):\n",
-    "    \"\"\"My Example class.\"\"\"\n",
+    "    \"\"\"My Example class.\n",
+    "\n",
+    "    Citation: Citation here\n",
+    "    \"\"\"\n",
     "\n",
     "    def __init__(self):\n",
     "        self.x = 0\n",

--- a/src/citation_compass/docstring_utils.py
+++ b/src/citation_compass/docstring_utils.py
@@ -113,20 +113,22 @@ def extract_citation(docstring):
                         break
         else:
             # We are already in a block, so check for the end of the block.
-            if (
-                block_type == "-"
-                and idx < len(all_lines) - 1
-                and len(all_lines[idx + 1]) > 1
-                and all_lines[idx + 1] == "-" * len(all_lines[idx + 1])
-            ):
+            if block_type == "-" and idx < len(all_lines) - 1:
                 # Section type citation blocks end when we hit the next section.
-                # Check by looking for the underling of the section header. If found,
-                # do not add the current line because it is the next section title.
-                block_type = "Done"
+                next_line = all_lines[idx + 1]
+
+                if len(next_line) > 1 and next_line == "-" * len(next_line):
+                    # Check by looking for the underline of the section header. If found,
+                    # do not add the current line because it is the next section title.
+                    block_type = "Done"
+                elif len(line) == 0 and len(next_line) == 0:
+                    # Sections can also end with two blank lines.
+                    block_type = "Done"
             elif block_type == ":" and len(line) == 0:
                 # End the 'keyword:' block when we hit a blank line.
                 block_type = "Done"
-            else:
+
+            if block_type != "Done":
                 # We are still in the block, so add the line to the current citation.
                 current_citation += " " + line
 

--- a/src/citation_compass/docstring_utils.py
+++ b/src/citation_compass/docstring_utils.py
@@ -1,15 +1,14 @@
 """A helper module for searching docstrings for citations."""
 
 _CITATION_HEADER_KEYWORDS = [
-    "acknowledgement",
-    "acknowledgements",
     "citation",
     "citations",
     "reference",
     "references",
 ]
 _CITATION_OTHER_KEYWORDS = [
-    "acknowledge",
+    "acknowledgement",
+    "acknowledgements",
     "arxiv",
     "attribute",
     "attribution",
@@ -49,14 +48,23 @@ def check_for_any_citation_keyword(string):
 
 
 def extract_citation(docstring):
-    """Extracts the citation from a docstring.
+    """Extracts citation(s) from a docstring.
 
     This function assumes that the citation is in the formatted to
     match this package using the "keyword: information" structure at
-    the start of a line.
+    the start of a line or underlined keyword.
 
-    For example, if the docstring contains:
+    For example, if the docstring contains either
+
     "Citation:
+        Author, Title, year.
+
+    Other information..."
+
+    or
+
+    "Citation
+     --------
         Author, Title, year.
 
     Other information..."
@@ -70,7 +78,7 @@ def extract_citation(docstring):
 
     Returns
     -------
-    str or None
+    extracted_citations: str or None
         The extracted citation or None if no citation is found.
     """
     if docstring is None or len(docstring) == 0:
@@ -79,20 +87,63 @@ def extract_citation(docstring):
     all_lines = [line.strip() for line in docstring.split("\n")]
 
     # We search for a line the starts with one of the citation keywords.
+    extracted_citations = ""
+    current_citation = ""
+    block_type = "None"
     for idx, line in enumerate(all_lines):
-        for keyword in _CITATION_SECTION_HEADERS:
-            if line.lower().startswith(keyword):
-                # We have a reference of the form "keyword: information".
-                # Take the rest of what is on that line and all following lines until
-                # we reach a blank line.
-                citation = line[len(keyword) + 1 :]
+        if block_type == "None":
+            # We are not currently in a citation block, so we check if this
+            # line is the start of that block.
+            if (
+                len(line) > 1
+                and line == "-" * len(line)
+                and idx > 0
+                and all_lines[idx - 1].lower() in _CITATION_HEADER_KEYWORDS
+            ):
+                # Check for an underlined section header. Note the section title will
+                # be on the previous line.
+                current_citation = ""
+                block_type = "-"
+            else:
+                # Check if we are in a citation block of the form 'keyword: information'.
+                for keyword in _CITATION_SECTION_HEADERS:
+                    if line.lower().startswith(keyword):
+                        block_type = ":"
+                        current_citation = line[len(keyword) + 1 :]
+                        break
+        else:
+            # We are already in a block, so check for the end of the block.
+            if (
+                block_type == "-"
+                and idx < len(all_lines) - 1
+                and len(all_lines[idx + 1]) > 1
+                and all_lines[idx + 1] == "-" * len(all_lines[idx + 1])
+            ):
+                # Section type citation blocks end when we hit the next section.
+                # Check by looking for the underling of the section header. If found,
+                # do not add the current line because it is the next section title.
+                block_type = "Done"
+            elif block_type == ":" and len(line) == 0:
+                # End the 'keyword:' block when we hit a blank line.
+                block_type = "Done"
+            else:
+                # We are still in the block, so add the line to the current citation.
+                current_citation += " " + line
 
-                idx += 1
-                while idx < len(all_lines) and len(all_lines[idx]) > 0:
-                    citation += " " + all_lines[idx]
-                    idx += 1
+        # We have finished the block, so add the citation to the extracted_citations.
+        # We do this outside the if-else block to ensure we get single line citations.
+        if block_type == "Done" or idx == len(all_lines) - 1:
+            if len(current_citation) > 0:
+                extracted_citations += "\n" + current_citation.strip()
+                current_citation = ""
 
-                return citation.strip()
+            # We are no longer in a citation block.
+            block_type = "None"
+
+    # Remove leading and trailing whitespace.
+    extracted_citations = extracted_citations.strip()
+    if len(extracted_citations) > 0:
+        return extracted_citations
     return None
 
 

--- a/tests/citation_compass/test_docstring_utils.py
+++ b/tests/citation_compass/test_docstring_utils.py
@@ -20,8 +20,8 @@ def test_check_docstring_for_keyword():
     assert check_for_any_citation_keyword(None) is False
 
 
-def test_extract_citation():
-    """Test that we can extract a citation from a docstring."""
+def test_extract_citation_colon():
+    """Test that we can extract a citation using the 'keyword:' format."""
     # Check an empty docstring.
     assert extract_citation("") is None
     assert extract_citation(None) is None
@@ -29,7 +29,6 @@ def test_extract_citation():
     # Start with single line docstrings.
     assert extract_citation("Citation: Author, Title, year.") == "Author, Title, year."
     assert extract_citation("Reference: Author, Title, year.") == "Author, Title, year."
-    assert extract_citation("Acknowledgement: Author, Title, year.") == "Author, Title, year."
     assert extract_citation("Info: Nothing to see here") is None
 
     # Test multi-line docstrings.
@@ -67,13 +66,82 @@ def test_extract_citation():
     -------
     More stuff.
 
-    Acknowledgements:
+    Citation:
         Author1, Author2,
         Title,
         journal,
         year
     """
     assert extract_citation(docstring) == "Author1, Author2, Title, journal, year"
+
+
+def test_extract_citation_underline():
+    """Test that we can extract a citation using the underline section format."""
+    docstring = """
+    Top material
+    ------------
+    Stuff here.
+
+    Citation
+    ------
+        Author1, Author2, Title, year.
+
+    Bottom material
+    ---------------
+    More stuff."""
+    assert extract_citation(docstring) == "Author1, Author2, Title, year."
+
+    docstring = """Function description.
+
+    Reference
+    -----------
+        Author1,
+        Author2,
+        Title,
+        year
+
+    Parameters
+    ----------
+    Stuff here.
+
+    Returns
+    -------
+    More stuff."""
+    assert extract_citation(docstring) == "Author1, Author2, Title, year"
+
+
+def test_extract_citation_multiple():
+    """Test that we can extract multiple citations from a string."""
+    # Test multi-line docstrings.
+    docstring = """Top material:
+    Stuff here.
+
+    Citation: Author1, Author2, Title1, year.
+
+    Citation: Author3, Author4, Title2, year.
+
+    Bottom material:
+    More stuff."""
+    assert extract_citation(docstring) == "Author1, Author2, Title1, year.\nAuthor3, Author4, Title2, year."
+
+    docstring = """Function description.
+
+    Reference
+    ---------
+        Author1, Author2, Title1, year.
+
+    Reference
+    ---------
+        Author3, Author4, Title2, year.
+
+    Parameters
+    ----------
+    Stuff here.
+
+    Returns
+    -------
+    More stuff."""
+    assert extract_citation(docstring) == "Author1, Author2, Title1, year.\nAuthor3, Author4, Title2, year."
 
 
 def test_extract_urls():

--- a/tests/citation_compass/test_docstring_utils.py
+++ b/tests/citation_compass/test_docstring_utils.py
@@ -109,6 +109,28 @@ def test_extract_citation_underline():
     More stuff."""
     assert extract_citation(docstring) == "Author1, Author2, Title, year"
 
+    # Sections end after two blank lines.
+    docstring = """Function description.
+
+    Reference
+    -----------
+        Author1,
+        Author2,
+        Title2,
+        year
+
+
+    This is not part of the citation.
+
+    Parameters
+    ----------
+    Stuff here.
+
+    Returns
+    -------
+    More stuff."""
+    assert extract_citation(docstring) == "Author1, Author2, Title2, year"
+
 
 def test_extract_citation_multiple():
     """Test that we can extract multiple citations from a string."""


### PR DESCRIPTION
This PR makes two changes to docstring parsing.

1) Allows the extractor to find multiple citations in the docstring (not just the first).

2) As per Kostya's request (on a TDAstro PR) also allow comments to be parse in the underline delimited docstring format:

Citation
--------
    information here