### PR TITLE
Add ability to track citation within a smaller context

### DIFF
--- a/docs/notebooks/intro_notebook.ipynb
+++ b/docs/notebooks/intro_notebook.ipynb
@@ -281,6 +281,60 @@
   },
   {
    "cell_type": "markdown",
+   "id": "808138d6",
+   "metadata": {},
+   "source": [
+    "## Citation Contexts\n",
+    "\n",
+    "Users might sometimes want only the citations for elements of code used within a given block of code.  CitationCompass provides a context manager that can perform tracking within a subset of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b55d926",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with cc.CitationContext(\"sub_context\") as context:\n",
+    "    print(f\"At the context start: {context.get_citations()}\")\n",
+    "    _ = my_function()\n",
+    "    print(f\"At the context end: {context.get_citations()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c57ed211",
+   "metadata": {},
+   "source": [
+    "The context specific list is automatically cleaned up after the `with` block.\n",
+    "\n",
+    "Note that only some citations are tracked at time of use. For example, citations to modules or functions with `track_used=False` will not show up within this context. Therefore care needs to be taken when using a context manager."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16d4a379",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with cc.CitationContext(\"sub_context\") as context:\n",
+    "    print(f\"At the context start: {context.get_citations()}\")\n",
+    "    _ = my_function_4(4)\n",
+    "    print(f\"At the context end: {context.get_citations()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4d6d71d",
+   "metadata": {},
+   "source": [
+    "Citation context managers can be assigned arbitrary (unique) labels and can be nested."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5dc3f891",
    "metadata": {},
    "source": [

--- a/src/citation_compass/__init__.py
+++ b/src/citation_compass/__init__.py
@@ -2,6 +2,7 @@ from ._version import __version__  # noqa
 
 from .citation import (
     CiteClass,
+    CitationContext,
     cite_function,
     cite_module,
     cite_object,
@@ -17,6 +18,7 @@ from .import_utils import get_all_imports
 
 __all__ = [
     "CiteClass",
+    "CitationContext",
     "cite_function",
     "cite_module",
     "cite_object",

--- a/src/citation_compass/citation_registry.py
+++ b/src/citation_compass/citation_registry.py
@@ -183,15 +183,15 @@ class CitationRegistry:
                     tracker.add(key)
 
     def num_trackers(self):
-        """Return the number of trackers in use.
+        """Return the number of custom trackers in use.
 
         Returns
         -------
         int
-            The number of trackers.
+            The number of custom trackers.
         """
-        # The number of custom trackers, plus the glabl used tracker.
-        return len(self.used_trackers) + 1
+        # The number of custom trackers.
+        return len(self.used_trackers)
 
     def start_used_tracker(self, name):
         """Add another tracker of used citations.

--- a/src/citation_compass/citation_registry.py
+++ b/src/citation_compass/citation_registry.py
@@ -1,0 +1,264 @@
+"""A helper module to collect citations from a software package."""
+
+import inspect
+
+from citation_compass.docstring_utils import (
+    extract_citation,
+    extract_urls,
+)
+
+
+def get_object_full_name(obj):
+    """Return the maximally qualified name of a thing.
+
+    Parameters
+    ----------
+    obj : object
+        The obj to get the name of.
+
+    Returns
+    -------
+    str
+        The fully qualified name of the thing.
+    """
+    # Try to determine the name of the "thing".
+    if hasattr(obj, "__qualname__"):
+        base_name = obj.__qualname__
+    elif hasattr(obj, "__name__"):
+        base_name = obj.__name__
+    elif hasattr(obj, "__class__"):
+        # If this is an object, use the class's name.
+        base_name = obj.__class__.__qualname__
+    else:
+        raise ValueError(f"Could not determine the name of {obj}")
+
+    # Get the string for the module (if we can find it).
+    module = inspect.getmodule(obj)
+    full_name = base_name if module is None else f"{module.__name__}.{base_name}"
+    return full_name
+
+
+class CitationEntry:
+    """A (data)class to store information about a citation.
+
+    Attributes
+    ----------
+    key : str
+        The name of the module, function, or other aspect where the citation is needed.
+    citation : str, optional
+        The citation string.
+    label : str, optional
+        The (optional) user-defined label for the citation.
+    urls : list of str
+        A list of URLs extracted from the citation string.
+    """
+
+    def __init__(self, key, citation=None, label=None):
+        self.key = key
+        self.citation = citation
+        self.label = label
+
+        if citation is None:
+            if label is not None and len(label) > 0:
+                self.citation = label
+            else:
+                self.citation = "No citation provided."
+
+        self.urls = extract_urls(self.citation)
+
+    def __hash__(self):
+        return hash(self.key)
+
+    def __str__(self):
+        return f"{self.key}: {self.citation}"
+
+    def __repr__(self):
+        return f"{self.key}:\n{self.citation}"
+
+    @classmethod
+    def from_object(cls, obj, label=None):
+        """Create a CitationEntry from any object (including a function or method).
+
+        Parameters
+        ----------
+        obj : object
+            The object from which to create the citation.
+        label : str, optional
+            The (optional) user-defined label for the citation.
+
+        Returns
+        -------
+        CitationEntry
+            The citation entry.
+        """
+        # Try to parse a citation from the object's docstring (if there is one).
+        if hasattr(obj, "__doc__"):
+            docstring = obj.__doc__
+        elif hasattr(obj, "__class__") and hasattr(obj.__class__, "__doc__"):
+            docstring = obj.__class__.__doc__
+        else:
+            docstring = ""
+        citation_text = extract_citation(docstring)
+        if citation_text is None:
+            citation_text = docstring
+
+        full_name = get_object_full_name(obj)
+
+        return cls(
+            key=full_name,
+            citation=citation_text,
+            label=label,
+        )
+
+
+class CitationRegistry:
+    """A class to store and manage citations for a software package.
+
+    Attributes
+    ----------
+    all_entries : dict
+        A dictionary mapping a annotation's key to its CitationEntry object.
+    used_entries : dict
+        A dictionary mapping the tracker's key to the set of keys it has seen.
+        We permit multiple trackers to be used in order to track citations within
+        context managers.
+    """
+
+    def __init__(self):
+        self.all_entries = {}
+        self.used_trackers = {}
+        self.used_trackers["global"] = set()
+
+    def __len__(self):
+        return len(self.all_entries)
+
+    def __contains__(self, key):
+        return key in self.all_entries
+
+    def __getitem__(self, key):
+        return self.all_entries[key]
+
+    def add(self, key, citation):
+        """Add a citation to the registry.
+
+        Parameters
+        ----------
+        key : str
+            The key for the citation.
+        citation : CitationEntry, str, or object
+            The citation entry to add.
+        """
+        if key not in self.all_entries:
+            if isinstance(citation, CitationEntry):
+                self.all_entries[key] = citation
+            elif isinstance(citation, str):
+                self.all_entries[key] = CitationEntry(key, citation)
+            else:
+                self.all_entries[key] = CitationEntry.from_object(citation)
+
+    def mark_used(self, key):
+        """Mark a citation as used.
+
+        Parameters
+        ----------
+        key : str
+            The key for the citation.
+        """
+        for tracker in self.used_trackers.values():
+            if key not in tracker:
+                tracker.add(key)
+
+    def num_trackers(self):
+        """Return the number of trackers in use.
+
+        Returns
+        -------
+        int
+            The number of trackers.
+        """
+        return len(self.used_trackers)
+
+    def start_used_tracker(self, name):
+        """Add another tracker of used citations.
+
+        Parameters
+        ----------
+        name : str
+            The name of the tracker.
+        """
+        if name not in self.used_trackers:
+            self.used_trackers[name] = set()
+        else:
+            raise KeyError(f"Tracker {name} already exists.")
+
+    def stop_used_tracker(self, name):
+        """Stop tracking used citations.
+
+        Parameters
+        ----------
+        name : str
+            The name of the tracker.
+
+        Returns
+        -------
+        list of CitationEntry
+            The list of used citations in the tracker.
+        """
+        if name in self.used_trackers:
+            used = [self.all_entries[key] for key in self.used_trackers[name]]
+            del self.used_trackers[name]
+        else:
+            raise KeyError(f"Tracker {name} does not exist.")
+        return used
+
+    def get_all_citations(self):
+        """Return a list of all citations in the software package.
+
+        Returns
+        -------
+        list of CitationEntry
+            A list of all citations in the software package.
+        """
+        return list(self.all_entries.values())
+
+    def get_used_citations(self, tracker_name=None):
+        """Return a list of the used citations in the software package.
+
+        Parameters
+        ----------
+        tracker_name : str, optional
+            The name of the tracker to get the used citations for.
+            If None, the global tracker is used.
+
+        Returns
+        -------
+        list of CitationEntry
+            A list of the citations used within the scope of the tracker.
+        """
+        if tracker_name is None:
+            tracker_name = "global"
+        if tracker_name not in self.used_trackers:
+            raise KeyError(f"Tracker {tracker_name} does not exist.")
+        return [self.all_entries[key] for key in self.used_trackers[tracker_name]]
+
+    def reset_used_citations(self, tracker_name=None):
+        """Reset the used citations for a tracker.
+
+        Parameters
+        ----------
+        tracker_name : str, optional
+            The name of the tracker to reset.
+            If None, the global tracker is reset.
+        """
+        if tracker_name is None:
+            tracker_name = "global"
+        if tracker_name not in self.used_trackers:
+            raise KeyError(f"Tracker {tracker_name} does not exist.")
+        self.used_trackers[tracker_name] = set()
+
+
+# ----------------------------------------------------------------------------
+# The GLOBAL citation registry -----------------------------------------------
+# ----------------------------------------------------------------------------
+
+CITATION_COMPASS_REGISTRY = CitationRegistry()

--- a/tests/citation_compass/test_citation.py
+++ b/tests/citation_compass/test_citation.py
@@ -1,4 +1,5 @@
 import fake_module
+import pytest
 
 from citation_compass import (
     cite_function,
@@ -7,6 +8,7 @@ from citation_compass import (
     get_all_citations,
     get_used_citations,
     reset_used_citations,
+    CitationContext,
 )
 
 
@@ -223,3 +225,54 @@ def test_find_in_citations():
 
     _ = fake_module.FakeCitedClass()
     assert len(find_in_citations("FakeCitedClass", True)) == 1
+
+
+def test_citation_context():
+    """Test the CitationContext class."""
+    reset_used_citations()
+
+    # Add some global citations.
+    _ = example_function_1()
+    _ = example_function_2()
+    assert len(get_used_citations()) == 2
+
+    # We don't have a tracker for this context (yet).
+    context_name = "my_context"
+    with pytest.raises(KeyError):
+        _ = get_used_citations(context_name)
+
+    with CitationContext(context_name) as context:
+        # Tracker now exists (with nothing in the context originally).
+        assert get_used_citations(context_name) == []
+        assert context.get_citations() == []
+
+        # We can add something specific to that context.
+        _ = example_function_x(10)
+        citations = context.get_citations()
+        assert len(citations) == 1
+        assert "test_citation.example_function_x: function_citation_x" in citations
+
+        # We can use multiple trackers.
+        with CitationContext("subcontext") as context2:
+            assert context.get_citations() == ["test_citation.example_function_x: function_citation_x"]
+            assert context2.get_citations() == []
+
+            _ = example_function_1()
+            citations = context.get_citations()
+            assert len(citations) == 2
+            assert "test_citation.example_function_1: function_citation_1" in citations
+            assert "test_citation.example_function_x: function_citation_x" in citations
+
+            assert context2.get_citations() == ["test_citation.example_function_1: function_citation_1"]
+
+        # The subcontext is now gone.
+        with pytest.raises(KeyError):
+            _ = get_used_citations("subcontext")
+
+    # Test the tracker is automatically deleted.
+    with pytest.raises(KeyError):
+        _ = get_used_citations(context_name)
+
+    # We can create a citation context without a name.
+    with CitationContext() as context:
+        assert len(context.name) > 0

--- a/tests/citation_compass/test_citation.py
+++ b/tests/citation_compass/test_citation.py
@@ -1,6 +1,5 @@
 import fake_module
 
-from citation_compass.citation import _get_full_name
 from citation_compass import (
     cite_function,
     cite_object,
@@ -27,18 +26,6 @@ def example_function_2():
 def example_function_x(x):
     """function_citation_x"""
     return x
-
-
-def test_get_full_name():
-    """Check that the full name is correctly generated."""
-    assert _get_full_name(example_function_1) == "test_citation.example_function_1"
-    assert _get_full_name(_get_full_name) == "citation_compass.citation._get_full_name"
-    assert _get_full_name(fake_module.fake_uncited_function) == "fake_module.fake_uncited_function"
-    assert _get_full_name(fake_module.FakeClass) == "fake_module.FakeClass"
-
-    obj = fake_module.FakeClass()
-    assert _get_full_name(obj) == "fake_module.FakeClass"
-    assert _get_full_name(obj.fake_method) == "fake_module.FakeClass.fake_method"
 
 
 def test_citations_all():

--- a/tests/citation_compass/test_citation_registry.py
+++ b/tests/citation_compass/test_citation_registry.py
@@ -95,9 +95,9 @@ def test_citations_registry():
     assert reg.get_used_citations()[0].key == "key1"
 
     # We can add a custom tracker. Initially it has nothing seen.
-    assert reg.num_trackers() == 1
+    assert reg.num_trackers() == 0
     reg.start_used_tracker("tracker1")
-    assert reg.num_trackers() == 2
+    assert reg.num_trackers() == 1
     assert len(reg.get_used_citations()) == 1
     assert len(reg.get_used_citations("tracker1")) == 0
 
@@ -126,7 +126,7 @@ def test_citations_registry():
     assert used[0].key == "key2"
     assert len(reg.get_used_citations()) == 2  # Global still has 2
 
-    assert reg.num_trackers() == 1
+    assert reg.num_trackers() == 0
     with pytest.raises(KeyError):
         _ = reg.get_used_citations("tracker1")
 

--- a/tests/citation_compass/test_citation_registry.py
+++ b/tests/citation_compass/test_citation_registry.py
@@ -1,0 +1,137 @@
+import pytest
+
+from citation_compass.citation_registry import (
+    get_object_full_name,
+    CitationEntry,
+    CitationRegistry,
+)
+
+
+def example_function_1():
+    """function_citation_1"""
+    return 1
+
+
+class ExampleClass:
+    """A fake class for testing."""
+
+    def __init__(self):
+        pass
+
+    def example_method(self):
+        """A fake class method for testing."""
+        return 0
+
+
+def test_get_object_full_name():
+    """Check that the full name is correctly generated."""
+    assert get_object_full_name(example_function_1) == "test_citation_registry.example_function_1"
+    assert (
+        get_object_full_name(get_object_full_name)
+        == "citation_compass.citation_registry.get_object_full_name"
+    )
+    assert get_object_full_name(ExampleClass) == "test_citation_registry.ExampleClass"
+    assert (
+        get_object_full_name(ExampleClass.example_method)
+        == "test_citation_registry.ExampleClass.example_method"
+    )
+
+    obj = ExampleClass()
+    assert get_object_full_name(obj) == "test_citation_registry.ExampleClass"
+    assert get_object_full_name(obj.example_method) == "test_citation_registry.ExampleClass.example_method"
+
+
+def test_citations_entry():
+    """Check that we can create and query a citation entry."""
+    entry = CitationEntry("key", "citation", "label")
+    assert entry.key == "key"
+    assert entry.citation == "citation"
+
+    # If no citation is provided, the label is used.
+    entry = CitationEntry("key", None, "label")
+    assert entry.citation == "label"
+
+    # We automatically extract URLs.
+    entry = CitationEntry("key", "http://example.com")
+    assert entry.urls == ["http://example.com"]
+
+    # We can create a citation entry from an object.
+    entry = CitationEntry.from_object(example_function_1)
+    assert entry.key == "test_citation_registry.example_function_1"
+    assert entry.citation == "function_citation_1"
+
+
+def test_citations_registry():
+    """Test that we can create and query a citation registry."""
+    reg = CitationRegistry()
+    assert len(reg) == 0
+
+    # We can add a citation entry as a CitationEntry object.
+    reg.add("key1", CitationEntry("key1", "citation1"))
+    assert len(reg) == 1
+    assert "key1" in reg
+    assert reg["key1"].citation == "citation1"
+    assert len(reg.get_all_citations()) == 1
+    assert reg.get_all_citations()[0].key == "key1"
+
+    # We can add a citation entry as a citation string.
+    reg.add("key2", "citation2")
+    assert len(reg) == 2
+    assert "key2" in reg
+    assert reg["key2"].citation == "citation2"
+    assert len(reg.get_all_citations()) == 2
+
+    # We can add a citation entry from an object.
+    reg.add("key3", example_function_1)
+    assert len(reg) == 3
+    assert "key3" in reg
+    assert reg["key3"].citation == "function_citation_1"
+    assert len(reg.get_all_citations()) == 3
+
+    # We can mark an entry as used.
+    assert len(reg.get_used_citations()) == 0
+    reg.mark_used("key1")
+    assert len(reg.get_used_citations()) == 1
+    assert reg.get_used_citations()[0].key == "key1"
+
+    # We can add a custom tracker. Initially it has nothing seen.
+    assert reg.num_trackers() == 1
+    reg.start_used_tracker("tracker1")
+    assert reg.num_trackers() == 2
+    assert len(reg.get_used_citations()) == 1
+    assert len(reg.get_used_citations("tracker1")) == 0
+
+    # We can mark an entry as used in a custom tracker.
+    reg.mark_used("key2")
+    assert len(reg.get_used_citations()) == 2  # Global has 2
+    assert len(reg.get_used_citations("tracker1")) == 1
+
+    # We can reset the used citations for a tracker.
+    reg.reset_used_citations("tracker1")
+    assert len(reg.get_used_citations()) == 2  # Global still has 2
+    assert len(reg.get_used_citations("tracker1")) == 0
+
+    # We can re-mark an entry as used in a custom tracker.
+    reg.mark_used("key2")
+    assert len(reg.get_used_citations()) == 2  # Global still has 2
+    assert len(reg.get_used_citations("tracker1")) == 1
+
+    # We can't start another tracker with the same name.
+    with pytest.raises(KeyError):
+        reg.start_used_tracker("tracker1")
+
+    # We can stop a tracker and get the used citations.
+    used = reg.stop_used_tracker("tracker1")
+    assert len(used) == 1
+    assert used[0].key == "key2"
+    assert len(reg.get_used_citations()) == 2  # Global still has 2
+
+    assert reg.num_trackers() == 1
+    with pytest.raises(KeyError):
+        _ = reg.get_used_citations("tracker1")
+
+    # We cannot stop or reset trackers that do not exist.
+    with pytest.raises(KeyError):
+        _ = reg.stop_used_tracker("tracker2")
+    with pytest.raises(KeyError):
+        reg.reset_used_citations("tracker2")


### PR DESCRIPTION
In addition to tracking "all" and "all used" citations, allow the user to track citations within a block of code. This PR refactors the citation tracking to allow multiple "used" trackers. These can be created via a new `CitationContext` context manager and only track citations used during the life of that context manager object.