### PR TITLE
Allow check_for_any_citation_keyword to take a custom list of keywords

### DIFF
--- a/src/citation_compass/docstring_utils.py
+++ b/src/citation_compass/docstring_utils.py
@@ -9,6 +9,8 @@ _CITATION_HEADER_KEYWORDS = [
 _CITATION_OTHER_KEYWORDS = [
     "acknowledgement",
     "acknowledgements",
+    "acknowledgment",
+    "acknowledgments",
     "arxiv",
     "attribution",
     "bibliography",

--- a/src/citation_compass/docstring_utils.py
+++ b/src/citation_compass/docstring_utils.py
@@ -10,7 +10,6 @@ _CITATION_OTHER_KEYWORDS = [
     "acknowledgement",
     "acknowledgements",
     "arxiv",
-    "attribute",
     "attribution",
     "bibliography",
     "cite",
@@ -20,7 +19,7 @@ _CITATION_SECTION_HEADERS = set([f"{keyword}:" for keyword in _CITATION_HEADER_K
 _CITATION_ALL_KEYWORDS = _CITATION_HEADER_KEYWORDS + _CITATION_OTHER_KEYWORDS
 
 
-def check_for_any_citation_keyword(string):
+def check_for_any_citation_keyword(string, keywords=None):
     """Checks a string for any of the keywords that indicate a citation,
     which can include the words in the middle of a sentence. As such, this approach
     is a heuristic and does not require the citation to be in a specific format. It
@@ -31,6 +30,8 @@ def check_for_any_citation_keyword(string):
     ----------
     string : str
         The string to check.
+    keywords : list of str, optional
+        A list of keywords to check for. If None, the default keywords are used.
 
     Returns
     -------
@@ -40,8 +41,11 @@ def check_for_any_citation_keyword(string):
     if string is None or len(string) == 0:
         return False
 
+    if keywords is None:
+        keywords = _CITATION_ALL_KEYWORDS
+
     for line in [line.lower() for line in string.split("\n")]:
-        for keyword in _CITATION_ALL_KEYWORDS:
+        for keyword in keywords:
             if keyword in line:
                 return True
     return False

--- a/tests/citation_compass/test_docstring_utils.py
+++ b/tests/citation_compass/test_docstring_utils.py
@@ -20,6 +20,14 @@ def test_check_docstring_for_keyword():
     assert check_for_any_citation_keyword(None) is False
 
 
+def test_check_docstring_for_keyword_custom():
+    """Check that the function correctly identifies docstrings with custom keywords."""
+    assert check_for_any_citation_keyword("This is a docstring.") is False
+    assert check_for_any_citation_keyword("This is a docstring.", keywords=["docstring"]) is True
+    assert check_for_any_citation_keyword("This is a citation.") is True
+    assert check_for_any_citation_keyword("This is a citation.", keywords=["nonexistent"]) is False
+
+
 def test_extract_citation_colon():
     """Test that we can extract a citation using the 'keyword:' format."""
     # Check an empty docstring.


### PR DESCRIPTION
Allow `check_for_any_citation_keyword()` to take a custom list of keywords in case users want to search for something specific.