### PR TITLE
Merge citations with duplicate keys

### DIFF
--- a/docs/notebooks/intro_notebook.ipynb
+++ b/docs/notebooks/intro_notebook.ipynb
@@ -368,9 +368,70 @@
   },
   {
    "cell_type": "markdown",
+   "id": "05e000c2",
+   "metadata": {},
+   "source": [
+    "## Duplicate Citation Keys\n",
+    "\n",
+    "Ideally the keys for every citable object should be unique. CitationCompass tries to ensure this for most automatically generated citations by including package information in the key for classes and functions. However there can still be collisions, especially when citations are manually added. In case of a duplicate key with a non-duplicate citation text, CitationCompass will append the citation information so that it all shows up.\n",
+    "\n",
+    "Let's start by looking at what happens if we try to re-add the exact same (key, text) combination."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0efcd05e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with cc.CitationContext(\"sub_context2\") as context:\n",
+    "    for i in range(5):\n",
+    "        cc.cite_inline(\"my_repeated_citation\", \"This is my custom citation.\")\n",
+    "        print(f\"After {i + 1} cite_inline: {context.get_citations()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "974dbc85",
+   "metadata": {},
+   "source": [
+    "Nothing changes with the repeared calls. But if we add different citation text, we see an expanded entry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00dabc7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with cc.CitationContext(\"sub_context3\") as context:\n",
+    "    for i in range(5):\n",
+    "        cc.cite_inline(\"my_numbered_citation\", f\"citation text {i}\")\n",
+    "        print(f\"After {i + 1} cite_inline: {context.get_citations()}\")\n",
+    "\n",
+    "    cc.cite_inline(\"my_numbered_citation\", \"citation text 0\")\n",
+    "    print(f\"After re-adding call 0 cite_inline: {context.get_citations()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b6ecead",
+   "metadata": {},
+   "source": [
+    "We continue to expand the citation string to include the new information when it is not a repeat of anything that has been previously added."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5dc3f891",
    "metadata": {},
    "source": [
+    "\n",
+    "\n",
+    "\n",
+    "\n",
     "## Conclusion\n",
     "\n",
     "CitationCompass is designed for a package's author to annotate their code and include functionality for retrieving the citations annotated. For example a command line tool may include a flag `--show_citations` that displays the citations (all or used) at the end of the run.\n",

--- a/docs/notebooks/intro_notebook.ipynb
+++ b/docs/notebooks/intro_notebook.ipynb
@@ -428,10 +428,6 @@
    "id": "5dc3f891",
    "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "\n",
-    "\n",
     "## Conclusion\n",
     "\n",
     "CitationCompass is designed for a package's author to annotate their code and include functionality for retrieving the citations annotated. For example a command line tool may include a flag `--show_citations` that displays the citations (all or used) at the end of the run.\n",

--- a/tests/citation_compass/test_citation.py
+++ b/tests/citation_compass/test_citation.py
@@ -199,9 +199,11 @@ def test_citations_used():
     used_citations.append("fake_module.InheritedFakeClass: A 3rd fake class for testing.")
     assert sorted(get_used_citations()) == sorted(used_citations)
 
-    # Test adding a manual citation for an object.
-    cite_inline("test_citation", "Citation string")
-    assert "test_citation: Citation string" in get_used_citations()
+    # Test adding a manual citation for a block of code.
+    cite_inline("test_citation_manual", "Citation string")
+    assert "test_citation_manual: Citation string" in get_used_citations()
+
+    # If we readd a seen citation key, it gets appended to the end of the list.
 
     # We can reset the list of used citation functions.
     reset_used_citations()


### PR DESCRIPTION
If a users adds the two citations with the same key, but different citation text, use a concatenation of the citation text.

Also includes some cleanups:
- `CitationRegistry.add()` only takes `CitationEntry` objects. All of the externally visible functions and wrappers can create a `CitationEntry` and pass it along, so the if-else logic in the add function was not needed.
- Remove the checks for duplicates in each helper and just rely on the duplicate check in `add()`
- Always generating the CitationEntry` object also allows us to access the name directly instead of calling `get_object_full_name` twice during an add.